### PR TITLE
Fix NaN (redundant param)

### DIFF
--- a/src/components/Simulator.vue
+++ b/src/components/Simulator.vue
@@ -416,7 +416,6 @@ function calculateSalary(
   if (hinuchComp != "ללא") {
     let hinuchVariable = hinuchComp == "כיתה א׳" ? hinuchA : hinuchRest;
     hinuchCompensation = calculateHinuch(
-      percentage,
       addition,
       mixedCompensationRaw,
       jewishYear,


### PR DESCRIPTION
Hinuch compensation was always NaN due to mismatch between function params and function call params 