### PR TITLE
Fix Kindergarten compensation + All roles and hinuch

### DIFF
--- a/src/components/Simulator.vue
+++ b/src/components/Simulator.vue
@@ -104,7 +104,7 @@
             <v-text-field
               v-if="kindergardenRole == 'ניהול גן (ותיקה באופק)'"
               type="number"
-              min="0"
+              min="1"
               max="10"
               v-model="kindergardenSeniority"
               label="וותק בניהול"
@@ -369,23 +369,23 @@ function calculateSalary(
   kindergardenSeniority
 ) {
   var base;
-  var addition;
+  var additionRaw;
   if (jewishYear == "תשפ״ב") {
     base = thisJewishYearBases[degree];
-    addition = 0;
+    additionRaw = 0;
   } else {
     base = nextJewishYearBases[degree];
     if (degree == "תואר ראשון") {
-      addition = firstDegreeAddition[level - 1];
+      additionRaw = firstDegreeAddition[level - 1];
     } else {
-      addition = secondDegreeAddition[level - 1];
+      additionRaw = secondDegreeAddition[level - 1];
     }
   }
   if (jewishYear == "תשפ״ג") {
-    addition /= 2;
+    additionRaw /= 2;
   }
-  addition *= percentage;
-
+  var addition = additionRaw * percentage;
+  
   let mixedCompensationRaw =
     base *
     (1 + level_7_5) ** (level - 1) *
@@ -401,14 +401,14 @@ function calculateSalary(
     jewishYear,
     roles[0] || "ללא",
     percentage,
-    addition,
+    additionRaw,
     mixedCompensationRaw
   );
   var roleCompensation2 = calcRoleCompensation(
     jewishYear,
     roles[1] || "ללא",
     percentage,
-    addition,
+    additionRaw,
     mixedCompensationRaw
   );
 
@@ -416,7 +416,7 @@ function calculateSalary(
   if (hinuchComp != "ללא") {
     let hinuchVariable = hinuchComp == "כיתה א׳" ? hinuchA : hinuchRest;
     hinuchCompensation = calculateHinuch(
-      addition,
+      additionRaw,
       mixedCompensationRaw,
       jewishYear,
       hinuchVariable
@@ -445,7 +445,7 @@ function calculateSalary(
       percentage,
       mixedCompensationRaw,
       jewishYear,
-      shiklitAddition
+      additionRaw
     );
   }
   let data = {

--- a/src/components/Simulator.vue
+++ b/src/components/Simulator.vue
@@ -416,7 +416,6 @@ function calculateSalary(
   if (hinuchComp != "ללא") {
     let hinuchVariable = hinuchComp == "כיתה א׳" ? hinuchA : hinuchRest;
     hinuchCompensation = calculateHinuch(
-      percentage,
       addition,
       mixedCompensationRaw,
       jewishYear,


### PR DESCRIPTION
A. Kindergarten compensation was calculating base on Shiklit 2016 ("shiklit") rather than Shiklit 2022 ("addition")
B. all roles and Hinuch were based on "addition" (already per job percentage) rather on additionRaw (newly added in this commit)